### PR TITLE
Optimise save

### DIFF
--- a/lib/entities/achievedMission.dart
+++ b/lib/entities/achievedMission.dart
@@ -1,0 +1,27 @@
+class AchievedMission {
+  int id;
+  int attempts;
+  bool satelliteUsed;
+
+  AchievedMission(this.id, this.attempts, this.satelliteUsed);
+
+  AchievedMission.fromData({
+    required this.id,
+    required this.attempts,
+    required this.satelliteUsed,
+  });
+
+  factory AchievedMission.fromJson(Map<String, dynamic> json) {
+    return AchievedMission.fromData(
+      id: json["id"] as int,
+      attempts: json["attempts"] as int,
+      satelliteUsed: json["satelliteUsed"] as bool,
+    );
+  }
+
+  Map toJson() => {
+        "id": id,
+        "attempts": attempts,
+        "satelliteUsed": satelliteUsed,
+      };
+}

--- a/lib/entities/team.dart
+++ b/lib/entities/team.dart
@@ -1,12 +1,12 @@
 import 'dart:convert';
 
-import 'package:the_crew_companion/entities/mission.dart';
+import 'package:the_crew_companion/entities/achievedMission.dart';
 
 class Team {
   late String name;
   late DateTime creationDate;
   late List<String> players;
-  late List<Mission> achievedMissions;
+  late List<AchievedMission> achievedMissions;
 
   Team() {
     name = "";
@@ -25,9 +25,9 @@ class Team {
     List<String> players = (jsonDecode(json['players']) as List<dynamic>)
         .map((p) => p.toString())
         .toList();
-    List<Mission> achievedMissions =
+    List<AchievedMission> achievedMissions =
         (jsonDecode(json['achievedMissions']) as List<dynamic>)
-            .map((am) => Mission.fromJson(am))
+            .map((am) => AchievedMission.fromJson(am))
             .toList();
     return Team.fromData(
         name: json['name'] as String,

--- a/lib/views/playGame.dart
+++ b/lib/views/playGame.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:the_crew_companion/constant.dart';
+import 'package:the_crew_companion/entities/achievedMission.dart';
 import 'package:the_crew_companion/entities/mission.dart';
 import 'package:the_crew_companion/entities/team.dart';
 import 'package:the_crew_companion/views/components/customDrawer.dart';
@@ -40,9 +41,13 @@ class PlayGameState extends State<PlayGame> {
     );
 
     if (confirmed == true) {
-      mission.attempts = int.parse(attempts.text == "" ? "1" : attempts.text);
-      mission.satelliteUsed = satUsed;
-      widget.team.achievedMissions.add(mission);
+      widget.team.achievedMissions.add(
+        AchievedMission(
+          mission.id,
+          int.parse(attempts.text == "" ? "1" : attempts.text),
+          satUsed,
+        ),
+      );
       await widget.controller.saveDatas();
       attempts.text = "";
       satUsed = false;

--- a/lib/views/teamStats.dart
+++ b/lib/views/teamStats.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:the_crew_companion/constant.dart';
+import 'package:the_crew_companion/entities/mission.dart';
 import 'package:the_crew_companion/entities/team.dart';
 import 'package:the_crew_companion/views/components/missionExpansionPanelList.dart';
 import 'package:the_crew_companion/controller.dart';
+import 'package:darq/darq.dart';
 
 class TeamStats extends StatefulWidget {
   const TeamStats({required this.controller, required this.team});
@@ -15,6 +17,24 @@ class TeamStats extends StatefulWidget {
 }
 
 class _TeamStatsState extends State<TeamStats> {
+  late List<Mission> achievedMissions;
+
+  @override
+  void initState() {
+    super.initState();
+
+    achievedMissions = widget.team.achievedMissions.select<Mission>(
+      (achievedMission, i) {
+        Mission mission = widget.controller.missions
+            .firstWhere((m) => m.id == achievedMission.id)
+            .copy;
+        mission.attempts = achievedMission.attempts;
+        mission.satelliteUsed = achievedMission.satelliteUsed;
+        return mission;
+      },
+    ).toList();
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -52,7 +72,7 @@ class _TeamStatsState extends State<TeamStats> {
                     ),
                   ),
                   MissionExpansionPanelList(
-                    missions: widget.team.achievedMissions,
+                    missions: achievedMissions,
                     expandedMissionId: widget.team.achievedMissions.last.id,
                   ),
                   Container(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -78,6 +78,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.3"
+  darq:
+    dependency: "direct main"
+    description:
+      name: darq
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.1"
   fake_async:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,7 @@ dependencies:
   google_fonts: ^2.1.0
   font_awesome_flutter: ^9.1.0
   progress_indicators: ^1.0.0
+  darq: ^1.1.1
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
Au lieu d'enregistrer tout l'objet mission (avec titre, description, objectifs), on serialize une version allégée avec l'id, et la saisie utilisateur.

Du coup quand on affiche les stats d'une équipe, on recharge les missions a afficher depuis le controller. Et on fait une copie de l'objet pour y injecter les attempts et satUsed..

Rétro compatible avec les anciennes save puisque le nouvel objet est une version allégée. On va ignorer les attributs inutiles dans le fromMap au premier chargement, et la prochaine save effacera ce qui sert plus.