### PR TITLE
Sortir la liste des contributeurs du fichier de traduction

### DIFF
--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -1,6 +1,5 @@
 {
   "applicationName": "The Crew Companion",
-  "applicationDeveloper": "[Joshua Arus](https://github.com/JoshuaArus), [Maxime Rauch](https://github.com/schnapse)",
 
   "commonYes": "Yes",
   "commonNo": "No",

--- a/assets/locales/fr.json
+++ b/assets/locales/fr.json
@@ -1,6 +1,5 @@
 {
   "applicationName": "The Crew Companion",
-  "applicationDeveloper": "[Joshua Arus](https://github.com/JoshuaArus), [Maxime Rauch](https://github.com/schnapse)",
 
   "commonYes": "Oui",
   "commonNo": "Non",

--- a/lib/views/about.dart
+++ b/lib/views/about.dart
@@ -17,6 +17,11 @@ class About extends StatefulWidget {
 }
 
 class _AboutState extends State<About> {
+  List<String> contributors = [
+    "[Joshua Arus](https://github.com/JoshuaArus)",
+    "[Maxime Rauch](https://github.com/schnapse)",
+  ];
+
   @override
   Widget build(BuildContext context) {
     String version = widget.controller.appVersion;
@@ -75,21 +80,11 @@ class _AboutState extends State<About> {
                             data:
                                 AppLocalizations.translate('aboutPresentation'),
                           ),
-                          MarkdownBody(
+                          CustomMarkdownBody(
                             data:
                                 AppLocalizations.translate('aboutDevelopedBy') +
-                                    " " +
-                                    AppLocalizations.translate(
-                                        'applicationDeveloper'),
-                            styleSheet: MarkdownStyleSheet(
-                              textAlign: WrapAlignment.spaceEvenly,
-                              p: TextStyle(
-                                height: 2,
-                              ),
-                            ),
-                            onTapLink: (text, url, title) {
-                              launch(url!);
-                            },
+                                    " : " +
+                                    contributors.join(" - "),
                           ),
                           CustomMarkdownBody(
                             data: AppLocalizations.translate(

--- a/lib/views/about.dart
+++ b/lib/views/about.dart
@@ -1,12 +1,11 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:the_crew_companion/constant.dart';
 import 'package:the_crew_companion/controller.dart';
 import 'package:the_crew_companion/utils/appLocalizations.dart';
+import 'package:the_crew_companion/views/components/customMarkdownBody.dart';
 import 'package:the_crew_companion/views/components/delayedAnimation.dart';
 import 'package:the_crew_companion/views/components/fallingAsteroids.dart';
 import 'package:the_crew_companion/views/components/jumpingHomeScreenTitle.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 class About extends StatefulWidget {
   const About({required this.controller});
@@ -72,18 +71,9 @@ class _AboutState extends State<About> {
                         mainAxisAlignment: MainAxisAlignment.spaceAround,
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          MarkdownBody(
+                          CustomMarkdownBody(
                             data:
                                 AppLocalizations.translate('aboutPresentation'),
-                            styleSheet: MarkdownStyleSheet(
-                              textAlign: WrapAlignment.spaceEvenly,
-                              p: TextStyle(
-                                height: 2,
-                              ),
-                            ),
-                            onTapLink: (text, url, title) {
-                              launch(url!);
-                            },
                           ),
                           MarkdownBody(
                             data:
@@ -101,18 +91,9 @@ class _AboutState extends State<About> {
                               launch(url!);
                             },
                           ),
-                          MarkdownBody(
+                          CustomMarkdownBody(
                             data: AppLocalizations.translate(
                                 'aboutFollowProject'),
-                            styleSheet: MarkdownStyleSheet(
-                              textAlign: WrapAlignment.spaceEvenly,
-                              p: TextStyle(
-                                height: 2,
-                              ),
-                            ),
-                            onTapLink: (text, url, title) {
-                              launch(url!);
-                            },
                           ),
                           Text(AppLocalizations.translate('aboutVersion') +
                               " " +

--- a/lib/views/components/customMarkdownBody.dart
+++ b/lib/views/components/customMarkdownBody.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:markdown/markdown.dart' as md;
+import 'package:url_launcher/url_launcher.dart';
+
+class CustomMarkdownBody extends MarkdownBody {
+  CustomMarkdownBody({
+    Key? key,
+    required String data,
+    bool selectable = false,
+    MarkdownStyleSheet? styleSheet,
+    MarkdownStyleSheetBaseTheme? styleSheetTheme,
+    SyntaxHighlighter? syntaxHighlighter,
+    MarkdownTapLinkCallback? onTapLink,
+    VoidCallback? onTapText,
+    String? imageDirectory,
+    List<md.BlockSyntax>? blockSyntaxes,
+    List<md.InlineSyntax>? inlineSyntaxes,
+    md.ExtensionSet? extensionSet,
+    MarkdownImageBuilder? imageBuilder,
+    MarkdownCheckboxBuilder? checkboxBuilder,
+    MarkdownBulletBuilder? bulletBuilder,
+    Map<String, MarkdownElementBuilder> builders =
+        const <String, MarkdownElementBuilder>{},
+    MarkdownListItemCrossAxisAlignment listItemCrossAxisAlignment =
+        MarkdownListItemCrossAxisAlignment.baseline,
+    shrinkWrap = true,
+    bool fitContent = true,
+  }) : super(
+          key: key,
+          data: data,
+          selectable: selectable,
+          styleSheet: styleSheet,
+          styleSheetTheme: styleSheetTheme,
+          syntaxHighlighter: syntaxHighlighter,
+          onTapLink: onTapLink,
+          onTapText: onTapText,
+          imageDirectory: imageDirectory,
+          blockSyntaxes: blockSyntaxes,
+          inlineSyntaxes: inlineSyntaxes,
+          extensionSet: extensionSet,
+          imageBuilder: imageBuilder,
+          checkboxBuilder: checkboxBuilder,
+          builders: builders,
+          listItemCrossAxisAlignment: listItemCrossAxisAlignment,
+          bulletBuilder: bulletBuilder,
+          fitContent: fitContent,
+        ) {
+    styleSheet = styleSheet ??
+        MarkdownStyleSheet(
+          textAlign: WrapAlignment.spaceEvenly,
+          p: TextStyle(
+            height: 2,
+          ),
+        );
+
+    onTapLink = onTapLink ??
+        (String text, String? url, String title) {
+          launch(url!);
+        };
+  }
+}

--- a/lib/views/rulesScreen.dart
+++ b/lib/views/rulesScreen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:the_crew_companion/controller.dart';
 import 'package:the_crew_companion/utils/appLocalizations.dart';
+import 'package:the_crew_companion/views/components/customMarkdownBody.dart';
 
 class Rules extends StatelessWidget {
   const Rules({required this.controller});
@@ -19,14 +19,8 @@ class Rules extends StatelessWidget {
         child: Center(
           child: Column(
             children: [
-              MarkdownBody(
+              CustomMarkdownBody(
                 data: AppLocalizations.translate('commonUnderConstruction'),
-                styleSheet: MarkdownStyleSheet(
-                  textAlign: WrapAlignment.center,
-                  p: TextStyle(
-                    height: 2,
-                  ),
-                ),
               ),
             ],
           ),


### PR DESCRIPTION
**Description**

J'ai sorti la liste des contributeurs au projet du fichier de traduction. On fera pas de traduction d'un nom ou d'une URL. Vu qu'on s'en sert que dans la page "A Propos", j'ai construit la liste directement dans la vue.

J'en ai profité pour créer un composant customMarkdownBody qui facilitera la mise en place d'une zone markdown avec texte justifié et lien cliquable.

**Screenshots**

![image](https://user-images.githubusercontent.com/1456867/123866385-46d43480-d92d-11eb-8251-9454cb819916.png)

![image](https://user-images.githubusercontent.com/1456867/123866626-9dda0980-d92d-11eb-90c6-f4b4c063016f.png)


**Issue link**

Close #28 