### PR TITLE
Ajout d'un LanguageNotifier pour changer la langue dans les "Settings"

### DIFF
--- a/lib/languageNotifier.dart
+++ b/lib/languageNotifier.dart
@@ -1,9 +1,0 @@
-import 'package:flutter/material.dart';
-import 'package:the_crew_companion/utils/appLocalizations.dart';
-
-class LanguageNotifier extends ChangeNotifier {
-  setLocale(Locale newLocale) async {
-    await AppLocalizations.delegate.load(newLocale);
-    notifyListeners();
-  }
-}

--- a/lib/languageNotifier.dart
+++ b/lib/languageNotifier.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/material.dart';
+import 'package:the_crew_companion/utils/appLocalizations.dart';
+
+class LanguageNotifier extends ChangeNotifier {
+  setLocale(Locale newLocale) async {
+    await AppLocalizations.delegate.load(newLocale);
+    notifyListeners();
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:the_crew_companion/languageNotifier.dart';
 import 'package:the_crew_companion/utils/appLocalizations.dart';
 import 'package:the_crew_companion/controller.dart';
 import 'package:the_crew_companion/themeNotifier.dart';
@@ -8,12 +9,10 @@ import 'package:the_crew_companion/views/homeScreen.dart';
 import 'package:the_crew_companion/views/splashScreen.dart';
 
 void main() {
-  runApp(
-    ChangeNotifierProvider<ThemeNotifier>(
-      create: (_) => ThemeNotifier(),
-      child: TheCrewCompanionApp(),
-    ),
-  );
+  runApp(MultiProvider(providers: [
+    ChangeNotifierProvider(create: (context) => LanguageNotifier()),
+    ChangeNotifierProvider(create: (context) => ThemeNotifier()),
+  ], child: TheCrewCompanionApp()));
 }
 
 class TheCrewCompanionApp extends StatelessWidget {
@@ -23,14 +22,17 @@ class TheCrewCompanionApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final themeNotifier = Provider.of<ThemeNotifier>(context);
+
     return MaterialApp(
       theme: themeNotifier.getThemeData(),
+      locale: AppLocalizations.currentLocale,
       localizationsDelegates: [
         AppLocalizations.delegate,
         GlobalMaterialLocalizations.delegate,
         GlobalWidgetsLocalizations.delegate,
       ],
-      supportedLocales: AppLocalizations.supportedLocales,
+      supportedLocales: AppLocalizations
+          .supportedLocales, // first element of supportedLocales as a fallback
       onGenerateTitle: (context) =>
           AppLocalizations.translate('applicationName'),
       home: FutureBuilder(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
-import 'package:the_crew_companion/languageNotifier.dart';
 import 'package:the_crew_companion/utils/appLocalizations.dart';
 import 'package:the_crew_companion/controller.dart';
 import 'package:the_crew_companion/themeNotifier.dart';
@@ -10,7 +9,7 @@ import 'package:the_crew_companion/views/splashScreen.dart';
 
 void main() {
   runApp(MultiProvider(providers: [
-    ChangeNotifierProvider(create: (context) => LanguageNotifier()),
+    ChangeNotifierProvider(create: (context) => AppLocalizations()),
     ChangeNotifierProvider(create: (context) => ThemeNotifier()),
   ], child: TheCrewCompanionApp()));
 }
@@ -22,10 +21,11 @@ class TheCrewCompanionApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final themeNotifier = Provider.of<ThemeNotifier>(context);
+    final appLocalizations = Provider.of<AppLocalizations>(context);
 
     return MaterialApp(
       theme: themeNotifier.getThemeData(),
-      locale: AppLocalizations.currentLocale,
+      locale: appLocalizations.getLocale(),
       localizationsDelegates: [
         AppLocalizations.delegate,
         GlobalMaterialLocalizations.delegate,

--- a/lib/utils/appLocalizations.dart
+++ b/lib/utils/appLocalizations.dart
@@ -4,8 +4,8 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
-class AppLocalizations {
-  static Locale? currentLocale;
+class AppLocalizations extends ChangeNotifier {
+  static Locale? _locale;
   static Map<String, String> _localizedStrings = {};
 
   static final List<Locale> supportedLocales = LanguageCodes.values
@@ -19,13 +19,24 @@ class AppLocalizations {
     return Localizations.of<AppLocalizations>(context, AppLocalizations);
   }
 
+  AppLocalizations();
+
   AppLocalizations._init(Locale locale) {
-    currentLocale = locale;
+    _locale = locale;
+  }
+
+  Locale? getLocale() {
+    return _locale;
+  }
+
+  setLocale(Locale newLocale) async {
+    await delegate.load(newLocale);
+    notifyListeners();
   }
 
   Future<void> load() async {
     String jsonString = await rootBundle
-        .loadString('assets/locales/${currentLocale!.languageCode}.json');
+        .loadString('assets/locales/${_locale!.languageCode}.json');
 
     Map<String, dynamic> jsonMap = json.decode(jsonString);
 

--- a/lib/views/settingsScreen.dart
+++ b/lib/views/settingsScreen.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import 'package:the_crew_companion/constant.dart';
 import 'package:the_crew_companion/controller.dart';
 import 'package:the_crew_companion/customThemes.dart';
+import 'package:the_crew_companion/languageNotifier.dart';
 import 'package:the_crew_companion/utils/appLocalizations.dart';
 import 'package:the_crew_companion/themeNotifier.dart';
 
@@ -22,9 +23,12 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
   @override
   Widget build(BuildContext context) {
-    currentLanguage = AppLocalizations.getCurrentLanguage();
+    final languageNotifier = Provider.of<LanguageNotifier>(context);
+    currentLanguage = AppLocalizations.currentLocale!.languageCode;
+
     final themeNotifier = Provider.of<ThemeNotifier>(context);
     currentTheme = themeNotifier.getTheme();
+
     return Scaffold(
       appBar: AppBar(
         title: Text(
@@ -49,10 +53,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
                       value: currentLanguage,
                       isExpanded: true,
                       onChanged: (String? newLanguage) {
-                        //TODO save language, reload translations, etc...
+                        if (newLanguage == null) return;
+                        languageNotifier.setLocale(Locale(newLanguage));
                         setState(() {
-                          currentLanguage = newLanguage ??
-                              AppLocalizations.fallbackLocale.languageCode;
+                          currentLanguage = newLanguage;
                         });
                       },
                       items: [

--- a/lib/views/settingsScreen.dart
+++ b/lib/views/settingsScreen.dart
@@ -63,7 +63,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                         .map(
                           (language) => DropdownMenuItem<String>(
                             value: language.value,
-                            child: Text(language.value),
+                            child: Text(language.displayValue),
                           ),
                         )
                         .toList(),

--- a/lib/views/settingsScreen.dart
+++ b/lib/views/settingsScreen.dart
@@ -3,7 +3,6 @@ import 'package:provider/provider.dart';
 import 'package:the_crew_companion/constant.dart';
 import 'package:the_crew_companion/controller.dart';
 import 'package:the_crew_companion/customThemes.dart';
-import 'package:the_crew_companion/languageNotifier.dart';
 import 'package:the_crew_companion/utils/appLocalizations.dart';
 import 'package:the_crew_companion/themeNotifier.dart';
 
@@ -23,8 +22,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final languageNotifier = Provider.of<LanguageNotifier>(context);
-    currentLanguage = AppLocalizations.currentLocale!.languageCode;
+    final appLocalizations = Provider.of<AppLocalizations>(context);
+    currentLanguage = appLocalizations.getLocale()!.languageCode;
 
     final themeNotifier = Provider.of<ThemeNotifier>(context);
     currentTheme = themeNotifier.getTheme();
@@ -52,7 +51,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                     isExpanded: true,
                     onChanged: (String? newLanguage) {
                       if (newLanguage == null) return;
-                      languageNotifier.setLocale(Locale(newLanguage));
+                      appLocalizations.setLocale(Locale(newLanguage));
                       setState(
                         () {
                           currentLanguage = newLanguage;


### PR DESCRIPTION
**Description**

**Ajout d'un LanguageNotifier pour permettre de changer la langue dans les Settings**
Au chargement de l'application, on récupère la langue de l'appareil. Lors de l'initialisation de `AppLocalizations` la fonction est appelée `isSupported`. Si la langue n'est pas supportée, on utilise la première fournie dans `supportedLocales`.

**Optimisation de la classe `AppLocalizations`**
De ce fait, le chargement des `_fallbackLocalizedStrings` n'est plus nécessaire car on va forcément charger une langue supportée.
De plus, si la traduction n'est pas disponible dans cette langue, on va afficher la clé de traduction plutôt qu'une traduction d'un fallback. C'est un choix personnel car ça permet d'alléger l'application et réduire le temps de chargement (une langue au lieu de deux). On peut imaginer un script d'aide au développement pour comparer les clés entre les fichiers de traduction pour vérifier ce qui est manquant.

J'ai également rendu `currentLocale` nullable pour qu'on puisse tester son initialisation : 
- Si elle est nulle on prend celle fournie par l'appareil (au première lancement)
- Si elle est renseignée on prend la courante (lors du changement de langue dans les paramètres)


