### PR TITLE
Issue 34 shared preferences

### DIFF
--- a/lib/controller.dart
+++ b/lib/controller.dart
@@ -24,13 +24,13 @@ class Controller {
   final List<Mission> missions = [];
   final List<RuleChapter> rules = [];
 
-  Future<void> saveDatas() async {
+  Future<void> saveTeams() async {
     final serializedTeams = jsonEncode(teams);
     final prefs = await SharedPreferences.getInstance();
     prefs.setString(storageKey, serializedTeams);
   }
 
-  Future<bool> readDatas() async {
+  Future<bool> readTeams() async {
     final prefs = await SharedPreferences.getInstance();
     final data = prefs.getString(storageKey) ?? "";
     if (data != "") {

--- a/lib/controller.dart
+++ b/lib/controller.dart
@@ -18,6 +18,7 @@ class Controller {
 
   String get storageKey => infos.packageName;
   String get settingsKey => storageKey + "_settings";
+  String get teamsKey => storageKey + "_teams";
   String get appName => infos.appName;
   String get appVersion => infos.version;
   String get buildNumber => infos.buildNumber;
@@ -69,12 +70,12 @@ class Controller {
   Future<void> saveTeams() async {
     final serializedTeams = jsonEncode(teams);
     final prefs = await SharedPreferences.getInstance();
-    prefs.setString(storageKey, serializedTeams);
+    prefs.setString(teamsKey, serializedTeams);
   }
 
   Future<bool> readTeams() async {
     final prefs = await SharedPreferences.getInstance();
-    final data = prefs.getString(storageKey) ?? "";
+    final data = prefs.getString(teamsKey) ?? "";
     if (data != "") {
       this.teams = (jsonDecode(data) as List<dynamic>)
           .map(

--- a/lib/controller.dart
+++ b/lib/controller.dart
@@ -1,20 +1,29 @@
 import 'dart:convert';
 
+import 'package:flutter/material.dart';
 import 'package:package_info_plus/package_info_plus.dart';
+import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:the_crew_companion/entities/mission.dart';
 import 'package:the_crew_companion/entities/ruleChapter.dart';
 import 'package:the_crew_companion/entities/team.dart';
 import 'package:the_crew_companion/services/missionService.dart';
 import 'package:the_crew_companion/services/ruleService.dart';
+import 'package:the_crew_companion/utils/appLocalizations.dart';
+import 'package:the_crew_companion/utils/customThemes.dart';
+import 'package:the_crew_companion/utils/themeNotifier.dart';
 
 class Controller {
   late PackageInfo infos;
 
   String get storageKey => infos.packageName;
+  String get settingsKey => storageKey + "_settings";
   String get appName => infos.appName;
   String get appVersion => infos.version;
   String get buildNumber => infos.buildNumber;
+
+  CustomThemes defaultTheme = CustomThemes.Dark;
+  Locale defaultLocale = AppLocalizations.supportedLocales.first;
 
   Future<void> init() async {
     infos = await PackageInfo.fromPlatform();
@@ -23,6 +32,39 @@ class Controller {
   List<Team> teams = [];
   final List<Mission> missions = [];
   final List<RuleChapter> rules = [];
+
+  Future<void> saveSettings(BuildContext context) async {
+    final appLocalizations = Provider.of<AppLocalizations>(context);
+    String currentLanguage = appLocalizations.getLocale()!.languageCode;
+
+    final themeNotifier = Provider.of<ThemeNotifier>(context);
+    String currentTheme = themeNotifier.getTheme().toString();
+
+    String serializedSettings = json.encode({
+      "language": currentLanguage,
+      "theme": currentTheme,
+    });
+
+    final prefs = await SharedPreferences.getInstance();
+    prefs.setString(settingsKey, serializedSettings);
+  }
+
+  Future<bool> readSettings() async {
+    final prefs = await SharedPreferences.getInstance();
+    final data = prefs.getString(settingsKey) ?? "";
+    if (data != "") {
+      Map<String, dynamic> serializedSettings =
+          (jsonDecode(data) as Map<String, dynamic>);
+      String language = serializedSettings["language"];
+      String theme = serializedSettings["theme"];
+
+      if (CustomThemesFactory.exist(theme)) {
+        defaultTheme = CustomThemesFactory.fromString(theme);
+      }
+      defaultLocale = Locale(language);
+    }
+    return true;
+  }
 
   Future<void> saveTeams() async {
     final serializedTeams = jsonEncode(teams);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,16 +8,51 @@ import 'package:the_crew_companion/views/screens/homeScreen.dart';
 import 'package:the_crew_companion/views/screens/splashScreen.dart';
 
 void main() {
-  runApp(MultiProvider(providers: [
-    ChangeNotifierProvider(create: (context) => AppLocalizations()),
-    ChangeNotifierProvider(create: (context) => ThemeNotifier()),
-  ], child: TheCrewCompanionApp()));
+  runApp(TheCrewCompanionApp());
 }
 
 class TheCrewCompanionApp extends StatelessWidget {
   final Controller controller = Controller();
 
   // This widget is the root of your application.
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder(
+      future: Future.wait(
+        [
+          controller.init(),
+          controller.readSettings(),
+          controller.readTeams(),
+        ],
+      ),
+      builder: (ctx, snpsht) {
+        if (snpsht.hasData) {
+          return MultiProvider(
+            providers: [
+              ChangeNotifierProvider(
+                create: (context) => AppLocalizations(controller.defaultLocale),
+              ),
+              ChangeNotifierProvider(
+                create: (context) =>
+                    ThemeNotifier(theme: controller.defaultTheme),
+              ),
+            ],
+            child: MainWindows(controller: controller),
+          );
+        } else
+          return SplashScreen();
+      },
+    );
+  }
+}
+
+class MainWindows extends StatelessWidget {
+  const MainWindows({
+    required this.controller,
+  });
+
+  final Controller controller;
+
   @override
   Widget build(BuildContext context) {
     final themeNotifier = Provider.of<ThemeNotifier>(context);
@@ -38,10 +73,9 @@ class TheCrewCompanionApp extends StatelessWidget {
       home: FutureBuilder(
         future: Future.wait(
           [
-            controller.init(),
-            controller.readDatas(),
             controller.populateRules(),
-            controller.populateMissions()
+            controller.populateMissions(),
+            controller.saveSettings(context),
           ],
         ),
         builder: (context, snapshot) {

--- a/lib/utils/appLocalizations.dart
+++ b/lib/utils/appLocalizations.dart
@@ -19,7 +19,9 @@ class AppLocalizations extends ChangeNotifier {
     return Localizations.of<AppLocalizations>(context, AppLocalizations);
   }
 
-  AppLocalizations();
+  AppLocalizations(Locale locale) {
+    AppLocalizations._init(locale);
+  }
 
   AppLocalizations._init(Locale locale) {
     _locale = locale;

--- a/lib/utils/customThemes.dart
+++ b/lib/utils/customThemes.dart
@@ -9,6 +9,10 @@ enum CustomThemes {
 }
 
 class CustomThemesFactory {
+  static bool exist(String val) {
+    return CustomThemes.values.any((element) => element.toString() == val);
+  }
+
   static CustomThemes fromString(String val) {
     return CustomThemes.values
         .firstWhere((element) => element.toString() == val);

--- a/lib/utils/themeNotifier.dart
+++ b/lib/utils/themeNotifier.dart
@@ -6,15 +6,15 @@ class ThemeNotifier extends ChangeNotifier {
 
   ThemeNotifier({CustomThemes theme = CustomThemes.Dark}) : this._theme = theme;
 
-  getTheme() {
+  CustomThemes getTheme() {
     return _theme.copy; //copy to avoid ref override
   }
 
-  getThemeData() {
+  ThemeData getThemeData() {
     return _theme.getThemeData();
   }
 
-  setTheme(CustomThemes newTheme) async {
+  void setTheme(CustomThemes newTheme) async {
     _theme = newTheme;
     notifyListeners();
   }

--- a/lib/utils/themeNotifier.dart
+++ b/lib/utils/themeNotifier.dart
@@ -4,7 +4,7 @@ import 'package:the_crew_companion/utils/customThemes.dart';
 class ThemeNotifier extends ChangeNotifier {
   CustomThemes _theme;
 
-  ThemeNotifier({CustomThemes theme = CustomThemes.Dark}) : this._theme = theme;
+  ThemeNotifier({required CustomThemes theme}) : this._theme = theme;
 
   CustomThemes getTheme() {
     return _theme.copy; //copy to avoid ref override

--- a/lib/views/screens/homeScreen.dart
+++ b/lib/views/screens/homeScreen.dart
@@ -44,7 +44,7 @@ class _HomeScreenState extends State<HomeScreen> {
     );
     if (created == true) {
       widget.controller.teams.add(newTeam);
-      await widget.controller.saveDatas();
+      await widget.controller.saveTeams();
 
       await Navigator.push(
         context,

--- a/lib/views/screens/playGameScreen.dart
+++ b/lib/views/screens/playGameScreen.dart
@@ -49,7 +49,7 @@ class _PlayGameScreenState extends State<PlayGameScreen> {
           satelliteUsed: satUsed,
         ),
       );
-      await widget.controller.saveDatas();
+      await widget.controller.saveTeams();
       attempts.text = "";
       satUsed = false;
       setState(() {});

--- a/lib/views/screens/teamListScreen.dart
+++ b/lib/views/screens/teamListScreen.dart
@@ -29,7 +29,7 @@ class _TeamListScreenState extends State<TeamListScreen> {
       ),
     );
     if (edited == true) {
-      await widget.controller.saveDatas();
+      await widget.controller.saveTeams();
       setState(() {}); //refresh UI
     }
   }
@@ -45,7 +45,7 @@ class _TeamListScreenState extends State<TeamListScreen> {
     );
     if (confirmed == true) {
       team.achievedMissions.clear();
-      await widget.controller.saveDatas();
+      await widget.controller.saveTeams();
       setState(() {});
     }
   }
@@ -71,7 +71,7 @@ class _TeamListScreenState extends State<TeamListScreen> {
     );
     if (confirmed == true) {
       widget.controller.teams.remove(team);
-      await widget.controller.saveDatas();
+      await widget.controller.saveTeams();
 
       if (widget.controller.teams.length == 0)
         Navigator.pop(context, true);


### PR DESCRIPTION
**Description**

- Enregistrement des paramètres (thème/langue) dans les sharedPreferences
- Réorganisation du code dans main.dart avec les provider pour améliorer un peu les perfs, et permettre de sauvegarder les prefs  automatiquement au rechargement de l'app
- Un peu de rework de code

J'ai créé une nouvelle clé pour les sharedPreferences (au format packageName_settings). Il faudrait faire pareil pour les teams (packageName_teams) pour faire propre, mais on casserait la rétro compatibilité 😏

Je sais pas trop si ma façon d'initialiser AppLocalization est la bonne avec cette histoire de delegate. Un avis @schnapse ? (en tout cas "ça marche" 🤣 )

**Screenshots**

![settings](https://user-images.githubusercontent.com/1456867/125184832-31121980-e221-11eb-9385-9a3c94ae3291.gif)

Close #34 