### PR TITLE
Issue 30 packageInfo

### DIFF
--- a/lib/controller.dart
+++ b/lib/controller.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:provider/provider.dart';
@@ -16,13 +15,7 @@ import 'package:the_crew_companion/utils/themeNotifier.dart';
 class Controller {
   late PackageInfo infos;
 
-  String get storageKey {
-    return defaultTargetPlatform == TargetPlatform.android ||
-            defaultTargetPlatform == TargetPlatform.iOS
-        ? infos.packageName
-        : infos.appName;
-  }
-
+  String get storageKey => "com.joshuaarus.the_crew_companion";
   String get settingsKey => storageKey + "_settings";
   String get teamsKey => storageKey + "_teams";
   String get appName => infos.appName;

--- a/lib/controller.dart
+++ b/lib/controller.dart
@@ -1,5 +1,5 @@
 import 'dart:convert';
-
+import 'package:flutter/foundation.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:the_crew_companion/entities/mission.dart';
@@ -11,13 +11,23 @@ import 'package:the_crew_companion/services/ruleService.dart';
 class Controller {
   late PackageInfo infos;
 
-  String get storageKey => infos.packageName;
   String get appName => infos.appName;
   String get appVersion => infos.version;
   String get buildNumber => infos.buildNumber;
 
+  String get storageKey {
+    return defaultTargetPlatform == TargetPlatform.android ||
+            defaultTargetPlatform == TargetPlatform.iOS
+        ? infos.packageName
+        : infos.appName;
+  }
+
   Future<void> init() async {
     infos = await PackageInfo.fromPlatform();
+
+    readDatas();
+    populateMissions();
+    populateRules();
   }
 
   List<Team> teams = [];

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -39,9 +39,6 @@ class TheCrewCompanionApp extends StatelessWidget {
         future: Future.wait(
           [
             controller.init(),
-            controller.readDatas(),
-            controller.populateRules(),
-            controller.populateMissions()
           ],
         ),
         builder: (context, snapshot) {


### PR DESCRIPTION
**Description**

Il est indiqué que le package [package_info_plus](https://pub.dev/packages/package_info_plus) est compatible pour la version web, ce qui est partiellement vrai. En effet, la propriété `packageName` n'est pas disponible dans un navigateur. Lors du build, un fichier `version.json` est généré grâce au [flutter-tools](https://github.com/flutter/flutter/pull/64644) qui est ensuite lu par le package [package_info_plus]. Comme on peut le voir dans [les sources](https://github.com/fluttercommunity/plus_plugins/blob/main/packages/package_info_plus/package_info_plus_web/lib/package_info_plus_web.dart), la propriété `packageName` n'est pas peuplée.

Ainsi, pour conserver la logique de récupération de la clé de stockage, on doit vérifier l'environnement puis retourner la valeur appropriée. Cette PR est une proposition de solution parmi plusieurs.

Close #30 