### PR TITLE
QR Code

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -33,9 +33,8 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.joshuaarus.the_crew_companion"
-        minSdkVersion 16
+        minSdkVersion 20
         targetSdkVersion 30
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.5.10'
     repositories {
         google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip

--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -44,6 +44,8 @@
   "teamDeleteConfirmation": "Are you sure you want to delete the $teamName team?",
   "teamDeletion": "Team deletion",
   "teamDelete": "Delete the team",
+  "teamLoadQrCode" : "Read from QR code",
+  "teamShare" : "Share the team",
   "teamEdit": "Edit the team",
   "teamSeeStatistics": "See team statistics",
   "teamTotalAttemptsCount": "Total number of attempts",

--- a/assets/locales/fr.json
+++ b/assets/locales/fr.json
@@ -45,6 +45,8 @@
   "teamDeletion": "Suppression de l'équipe",
   "teamDelete": "Supprimer l'équipe",
   "teamEdit": "Editer l'équipe",
+  "teamShare" : "Partager l'équipe",
+  "teamLoadQrCode" : "Charger depuis un QR code",
   "teamSeeStatistics": "Voir les statistiques l'équipe",
   "teamTotalAttemptsCount": "Nombre de tentatives totales",
   "teamNoMission": "Aucune mission réalisée jusqu'à présent",

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -41,5 +41,9 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>io.flutter.embedded_views_preview</key>
+	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string>This app needs camera access to scan QR codes</string>
 </dict>
 </plist>

--- a/lib/views/screens/homeScreen.dart
+++ b/lib/views/screens/homeScreen.dart
@@ -112,9 +112,10 @@ class _HomeScreenState extends State<HomeScreen> {
                             height: 60,
                           ),
                           HomeScreenButton(
-                            text: AppLocalizations.translate('homeLoadGame'),
+                            text: widget.controller.teams.length == 0
+                                ? AppLocalizations.translate('teamLoadQrCode')
+                                : AppLocalizations.translate('homeLoadGame'),
                             onPressed: _goToTeamList,
-                            disabled: widget.controller.teams.length == 0,
                           ),
                         ],
                       ),

--- a/lib/views/screens/qrCodeScanner.dart
+++ b/lib/views/screens/qrCodeScanner.dart
@@ -13,7 +13,6 @@ class QrCodeScannerScreen extends StatefulWidget {
 
 class _QrCodeScannerScreenState extends State<QrCodeScannerScreen> {
   final GlobalKey qrKey = GlobalKey(debugLabel: 'QR');
-  Barcode? result;
   late QRViewController controller;
 
   // In order to get hot reload to work we need to pause the camera if the platform
@@ -34,19 +33,9 @@ class _QrCodeScannerScreenState extends State<QrCodeScannerScreen> {
       body: Column(
         children: <Widget>[
           Expanded(
-            flex: 5,
             child: QRView(
               key: qrKey,
               onQRViewCreated: _onQRViewCreated,
-            ),
-          ),
-          Expanded(
-            flex: 1,
-            child: Center(
-              child: (result != null)
-                  ? Text(
-                      'Barcode Type: ${describeEnum(result!.format)}   Data: ${result!.code}')
-                  : Text('Scan a code'),
             ),
           )
         ],

--- a/lib/views/screens/qrCodeScanner.dart
+++ b/lib/views/screens/qrCodeScanner.dart
@@ -1,0 +1,70 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:qr_code_scanner/qr_code_scanner.dart';
+
+class QrCodeScannerScreen extends StatefulWidget {
+  const QrCodeScannerScreen({Key? key}) : super(key: key);
+
+  @override
+  _QrCodeScannerScreenState createState() => _QrCodeScannerScreenState();
+}
+
+class _QrCodeScannerScreenState extends State<QrCodeScannerScreen> {
+  final GlobalKey qrKey = GlobalKey(debugLabel: 'QR');
+  Barcode? result;
+  late QRViewController controller;
+
+  // In order to get hot reload to work we need to pause the camera if the platform
+  // is android, or resume the camera if the platform is iOS.
+  @override
+  void reassemble() {
+    super.reassemble();
+    if (Platform.isAndroid) {
+      controller.pauseCamera();
+    } else if (Platform.isIOS) {
+      controller.resumeCamera();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Column(
+        children: <Widget>[
+          Expanded(
+            flex: 5,
+            child: QRView(
+              key: qrKey,
+              onQRViewCreated: _onQRViewCreated,
+            ),
+          ),
+          Expanded(
+            flex: 1,
+            child: Center(
+              child: (result != null)
+                  ? Text(
+                      'Barcode Type: ${describeEnum(result!.format)}   Data: ${result!.code}')
+                  : Text('Scan a code'),
+            ),
+          )
+        ],
+      ),
+    );
+  }
+
+  void _onQRViewCreated(QRViewController controller) {
+    this.controller = controller;
+    controller.scannedDataStream.listen((scanData) {
+      dispose();
+      Navigator.pop(context, scanData.code);
+    });
+  }
+
+  @override
+  void dispose() {
+    controller.dispose();
+    super.dispose();
+  }
+}

--- a/lib/views/screens/teamListScreen.dart
+++ b/lib/views/screens/teamListScreen.dart
@@ -23,6 +23,17 @@ class TeamListScreen extends StatefulWidget {
 }
 
 class _TeamListScreenState extends State<TeamListScreen> {
+  @override
+  void initState() {
+    super.initState();
+
+    if (widget.controller.teams.isEmpty) {
+      Future.delayed(Duration(milliseconds: 100), () {
+        _goToScanQrCode();
+      });
+    }
+  }
+
   void _editTeam(Team team) async {
     final edited = await Navigator.push(
       context,
@@ -81,16 +92,18 @@ class _TeamListScreenState extends State<TeamListScreen> {
   }
 
   void _goToScanQrCode() async {
-    String serializedTeam = await Navigator.push(
+    String? serializedTeam = await Navigator.push(
       context,
       new MaterialPageRoute(
         builder: (BuildContext context) => QrCodeScannerScreen(),
       ),
     );
 
-    Team newTeam = Team.fromJson(serializedTeam);
-
-    widget.controller.teams.add(newTeam);
+    if (serializedTeam != null && serializedTeam != "") {
+      Team newTeam = Team.fromJson(serializedTeam);
+      widget.controller.teams.add(newTeam);
+      await widget.controller.saveTeams();
+    }
 
     setState(() {});
   }

--- a/lib/views/screens/teamListScreen.dart
+++ b/lib/views/screens/teamListScreen.dart
@@ -1,5 +1,6 @@
 import 'package:confirm_dialog/confirm_dialog.dart';
 import 'package:flutter/material.dart';
+import 'package:qr_flutter/qr_flutter.dart';
 import 'package:the_crew_companion/utils/constant.dart';
 import 'package:the_crew_companion/controller.dart';
 import 'package:the_crew_companion/entities/team.dart';
@@ -8,6 +9,7 @@ import 'package:the_crew_companion/views/components/teamName.dart';
 import 'package:the_crew_companion/views/components/teamPlayers.dart';
 import 'package:the_crew_companion/views/components/teamProgress.dart';
 import 'package:the_crew_companion/views/screens/playGameScreen.dart';
+import 'package:the_crew_companion/views/screens/qrCodeScanner.dart';
 import 'package:the_crew_companion/views/screens/teamCreationScreen.dart';
 import 'package:the_crew_companion/views/screens/teamStatsScreen.dart';
 
@@ -34,6 +36,24 @@ class _TeamListScreenState extends State<TeamListScreen> {
     }
   }
 
+  void _shareTeam(Team team) {
+    showDialog(
+      context: context,
+      builder: (_) => new Dialog(
+        child: Container(
+          width: 300,
+          height: 300,
+          child: QrImage(
+            data: team.toJson(),
+            size: 200,
+            backgroundColor: Colors.white,
+          ),
+          // child: Text("coucou"),
+        ),
+      ),
+    );
+  }
+
   void _resetProgress(Team team) async {
     bool confirmed = await confirm(
       context,
@@ -58,6 +78,21 @@ class _TeamListScreenState extends State<TeamListScreen> {
             TeamStatsScreen(controller: widget.controller, team: team),
       ),
     );
+  }
+
+  void _goToScanQrCode() async {
+    String serializedTeam = await Navigator.push(
+      context,
+      new MaterialPageRoute(
+        builder: (BuildContext context) => QrCodeScannerScreen(),
+      ),
+    );
+
+    Team newTeam = Team.fromJson(serializedTeam);
+
+    widget.controller.teams.add(newTeam);
+
+    setState(() {});
   }
 
   void _removeTeam(Team team) async {
@@ -109,8 +144,12 @@ class _TeamListScreenState extends State<TeamListScreen> {
             value: 3,
           ),
           PopupMenuItem(
-            child: Text(AppLocalizations.translate('teamDelete')),
+            child: Text(AppLocalizations.translate('teamShare')),
             value: 4,
+          ),
+          PopupMenuItem(
+            child: Text(AppLocalizations.translate('teamDelete')),
+            value: 5,
           ),
         ];
       },
@@ -127,6 +166,9 @@ class _TeamListScreenState extends State<TeamListScreen> {
             _resetProgress(team);
             break;
           case 4:
+            _shareTeam(team);
+            break;
+          case 5:
             _removeTeam(team);
             break;
         }
@@ -140,6 +182,15 @@ class _TeamListScreenState extends State<TeamListScreen> {
       appBar: AppBar(
         title: Text(widget.controller.appName),
         centerTitle: true,
+        actions: [
+          IconButton(
+            onPressed: _goToScanQrCode,
+            icon: Icon(
+              Icons.qr_code_2,
+            ),
+            tooltip: AppLocalizations.translate('teamLoadQrCode'),
+          ),
+        ],
       ),
       body: Container(
         padding: EdgeInsets.symmetric(vertical: defaultPadding / 2),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -567,6 +567,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
+  qr:
+    dependency: transitive
+    description:
+      name: qr
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.0"
+  qr_code_scanner:
+    dependency: "direct main"
+    description:
+      name: qr_code_scanner
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.5.2"
+  qr_flutter:
+    dependency: "direct main"
+    description:
+      name: qr_flutter
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.0.0"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,8 @@ dependencies:
   package_info_plus: ^1.0.4
   progress_indicators: ^1.0.0
   provider: ^5.0.0
+  qr_code_scanner: ^0.5.2
+  qr_flutter: ^4.0.0
   shared_preferences: ^2.0.6
   url_launcher: ^6.0.9
 

--- a/web/index.html
+++ b/web/index.html
@@ -94,5 +94,11 @@
       loadMainDartJs();
     }
   </script>
+
+
+<script src="https://cdn.jsdelivr.net/npm/jsqr@1.3.1/dist/jsQR.min.js"></script>
+
+
+
 </body>
 </html>


### PR DESCRIPTION
**Description**

Permet de partager une progression via un QR code vers un autre appareil.

Actuellement, dans l'écran de chargement d'une équipe, on peut générer le QR code qui contient la version JSON de l'équipe.

On peut également scanner un code avec le bouton ajouté en haut à droite de cette même page.

Pour pouvoir scanner un QR code dès le 1er lancement de l'application, j'ai modifié le wording du homeScreen, et j'ouvre automatiquement la caméra sur la page teamList si pas encore d'équipe.

J'ai voulu utiliser [screen](https://pub.dev/packages/screens) mais la lib est deprecated (non null-safety), et pas trouvé d'équivalence.

**Screenshots**

![Screenshot_1627233069](https://user-images.githubusercontent.com/1456867/126907500-942a2bd4-3ed4-48a7-ae11-f66ea0397150.png)

![Screenshot_1627234589](https://user-images.githubusercontent.com/1456867/126908098-122e4c51-f944-4f07-9bf4-8bc604976184.png)
