### PR TITLE
feat(Game): Ajout d'un chronomètre pour mesurer la durée d'une mission ainsi que d'un bloc pour saisir un commentaire optionnel

### DIFF
--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -14,6 +14,7 @@
   "commonLast": "Lastly",
   "commonDisruptedCommunications": "Disrupted communications",
   "commonFaceDownCards": "Face down cards",
+  "commonComments": "Comments",
 
   "menuHome": "Home",
   "menuRules": "The rules",
@@ -27,6 +28,8 @@
   "missionNext": "Next mission",
   "missionList": "List of missions",
 
+  "gameStartTimer": "Start the timer",
+  "gameTimeElapsed": "Mission elapsed time",
   "gameValidateMission": "Validate the mission",
   "gameTeamStatistics": "Team statistics",
   "gameAttemptsCount": "Number of attempts",

--- a/assets/locales/fr.json
+++ b/assets/locales/fr.json
@@ -14,6 +14,7 @@
   "commonLast": "En dernier",
   "commonDisruptedCommunications": "Communications perturbées",
   "commonFaceDownCards": "Cartes faces cachées",
+  "commonComments": "Commentaires",
 
   "menuHome": "Accueil",
   "menuRules": "Les règles",
@@ -26,7 +27,9 @@
 
   "missionNext": "Prochaine mission",
   "missionList": "Liste des missions",
-
+  
+  "gameStartTimer": "Lancer le chonomètre",
+  "gameTimeElapsed": "Durée de la mission",
   "gameValidateMission": "Valider la mission",
   "gameTeamStatistics": "Statistiques de l'équipe",
   "gameAttemptsCount": "Nombre de tentatives",

--- a/lib/entities/achievedMission.dart
+++ b/lib/entities/achievedMission.dart
@@ -5,21 +5,30 @@ class AchievedMission {
   int id;
   int attempts;
   bool satelliteUsed;
+  String? comment;
+  int? durationInSeconds;
+
   AchievedMission({
     required this.id,
     required this.attempts,
     required this.satelliteUsed,
+    this.comment,
+    this.durationInSeconds,
   });
 
   AchievedMission copyWith({
     int? id,
     int? attempts,
     bool? satelliteUsed,
+    String? comment,
+    int? durationInSeconds,
   }) {
     return AchievedMission(
       id: id ?? this.id,
       attempts: attempts ?? this.attempts,
       satelliteUsed: satelliteUsed ?? this.satelliteUsed,
+      comment: comment ?? this.comment,
+      durationInSeconds: durationInSeconds ?? this.durationInSeconds,
     );
   }
 
@@ -28,6 +37,8 @@ class AchievedMission {
       'id': id,
       'attempts': attempts,
       'satelliteUsed': satelliteUsed,
+      'comment': comment,
+      'durationInSeconds': durationInSeconds,
     };
   }
 
@@ -36,6 +47,8 @@ class AchievedMission {
       id: map['id'],
       attempts: map['attempts'],
       satelliteUsed: map['satelliteUsed'],
+      comment: map['comment'],
+      durationInSeconds: map['durationInSeconds'],
     );
   }
 
@@ -45,8 +58,9 @@ class AchievedMission {
       AchievedMission.fromMap(json.decode(source));
 
   @override
-  String toString() =>
-      'AchievedMission(id: $id, attempts: $attempts, satelliteUsed: $satelliteUsed)';
+  String toString() {
+    return 'AchievedMission(id: $id, attempts: $attempts, satelliteUsed: $satelliteUsed, comment: $comment, durationInSeconds: $durationInSeconds)';
+  }
 
   @override
   bool operator ==(Object other) {
@@ -55,9 +69,17 @@ class AchievedMission {
     return other is AchievedMission &&
         other.id == id &&
         other.attempts == attempts &&
-        other.satelliteUsed == satelliteUsed;
+        other.satelliteUsed == satelliteUsed &&
+        other.comment == comment &&
+        other.durationInSeconds == durationInSeconds;
   }
 
   @override
-  int get hashCode => id.hashCode ^ attempts.hashCode ^ satelliteUsed.hashCode;
+  int get hashCode {
+    return id.hashCode ^
+        attempts.hashCode ^
+        satelliteUsed.hashCode ^
+        comment.hashCode ^
+        durationInSeconds.hashCode;
+  }
 }

--- a/lib/entities/mission.dart
+++ b/lib/entities/mission.dart
@@ -12,6 +12,8 @@ class Mission {
   int attempts;
   bool satelliteUsed;
   List<AimOption> aimOptions;
+  String? comment;
+  int? durationInSeconds;
 
   Mission({
     required this.id,
@@ -19,6 +21,8 @@ class Mission {
     required this.attempts,
     required this.satelliteUsed,
     required this.aimOptions,
+    this.comment,
+    this.durationInSeconds,
   });
 
   String get title {
@@ -37,6 +41,8 @@ class Mission {
     int? attempts,
     bool? satelliteUsed,
     List<AimOption>? aimOptions,
+    String? comment,
+    int? durationInSeconds,
   }) {
     return Mission(
       id: id ?? this.id,
@@ -44,18 +50,20 @@ class Mission {
       attempts: attempts ?? this.attempts,
       satelliteUsed: satelliteUsed ?? this.satelliteUsed,
       aimOptions: aimOptions ?? this.aimOptions,
+      comment: comment ?? this.comment,
+      durationInSeconds: durationInSeconds ?? this.durationInSeconds,
     );
   }
 
   Map<String, dynamic> toMap() {
     return {
       'id': id,
-      'title': title,
-      'description': description,
       'aimCount': aimCount,
       'attempts': attempts,
       'satelliteUsed': satelliteUsed,
       'aimOptions': aimOptions.map((x) => x.toString()).toList(),
+      'comment': comment,
+      'durationInSeconds': durationInSeconds,
     };
   }
 
@@ -67,6 +75,8 @@ class Mission {
       satelliteUsed: map['satelliteUsed'],
       aimOptions: List<AimOption>.from(
           map['aimOptions']?.map((x) => AimOptionFactory.fromString(x))),
+      comment: map['comment'],
+      durationInSeconds: map['durationInSeconds'],
     );
   }
 
@@ -77,7 +87,7 @@ class Mission {
 
   @override
   String toString() {
-    return 'Mission(id: $id, title: $title, description: $description, aimCount: $aimCount, attempts: $attempts, satelliteUsed: $satelliteUsed, aimOptions: $aimOptions)';
+    return 'Mission(id: $id, aimCount: $aimCount, attempts: $attempts, satelliteUsed: $satelliteUsed, aimOptions: $aimOptions, comment: $comment, durationInSeconds: $durationInSeconds)';
   }
 
   @override
@@ -86,22 +96,22 @@ class Mission {
 
     return other is Mission &&
         other.id == id &&
-        other.title == title &&
-        other.description == description &&
         other.aimCount == aimCount &&
         other.attempts == attempts &&
         other.satelliteUsed == satelliteUsed &&
-        listEquals(other.aimOptions, aimOptions);
+        listEquals(other.aimOptions, aimOptions) &&
+        other.comment == comment &&
+        other.durationInSeconds == durationInSeconds;
   }
 
   @override
   int get hashCode {
     return id.hashCode ^
-        title.hashCode ^
-        description.hashCode ^
         aimCount.hashCode ^
         attempts.hashCode ^
         satelliteUsed.hashCode ^
-        aimOptions.hashCode;
+        aimOptions.hashCode ^
+        comment.hashCode ^
+        durationInSeconds.hashCode;
   }
 }

--- a/lib/utils/stringFormatter.dart
+++ b/lib/utils/stringFormatter.dart
@@ -1,0 +1,8 @@
+mixin StringFormatter {
+  static String formatDuration(Duration duration) {
+    String twoDigits(int n) => n.toString().padLeft(2, "0");
+    final String twoDigitMinutes = twoDigits(duration.inMinutes.remainder(60));
+    final String twoDigitSeconds = twoDigits(duration.inSeconds.remainder(60));
+    return "$twoDigitMinutes:$twoDigitSeconds";
+  }
+}

--- a/lib/views/components/deepSpace.dart
+++ b/lib/views/components/deepSpace.dart
@@ -47,9 +47,6 @@ class _DeepSpaceState extends State<DeepSpace> {
         Duration(
           milliseconds: animationDuration,
         ), () {
-      print("opacity1 : " + opacity1.toString());
-      print("opacity2 : " + opacity2.toString());
-
       setState(() {
         double tmp = opacity1;
         opacity1 = opacity2;

--- a/lib/views/components/missionExpansionPanelList.dart
+++ b/lib/views/components/missionExpansionPanelList.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:the_crew_companion/utils/constant.dart';
 import 'package:the_crew_companion/entities/mission.dart';
 import 'package:the_crew_companion/utils/appLocalizations.dart';
+import 'package:the_crew_companion/views/components/customMarkdownBody.dart';
 import 'package:the_crew_companion/views/components/missionDescription.dart';
 
 class MissionExpansionPanelList extends StatefulWidget {
@@ -28,6 +29,13 @@ class _MissionExpansionPanelListState extends State<MissionExpansionPanelList> {
     setState(() {
       expandedMissionId = !isExpanded ? widget.missions[index].id : null;
     });
+  }
+
+  String _printDuration(Duration d) {
+    String twoDigits(int n) => n.toString().padLeft(2, "0");
+    String twoDigitMinutes = twoDigits(d.inMinutes.remainder(60));
+    String twoDigitSeconds = twoDigits(d.inSeconds.remainder(60));
+    return "$twoDigitMinutes:$twoDigitSeconds";
   }
 
   List<Widget> buildChildrens(Mission mission) {
@@ -62,7 +70,44 @@ class _MissionExpansionPanelListState extends State<MissionExpansionPanelList> {
               onChanged: null,
             )
           ],
-        )
+        ),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(AppLocalizations.translate('gameTimeElapsed') + " : "),
+            Text(
+              mission.durationInSeconds == null
+                  ? "-"
+                  : _printDuration(
+                      Duration(seconds: mission.durationInSeconds!),
+                    ),
+            ),
+          ],
+        ),
+        if (mission.comment != null && mission.comment! != "")
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(AppLocalizations.translate('commonComments') + " : "),
+              Container(
+                width: double.infinity,
+                decoration: BoxDecoration(
+                  border: Border.all(color: Colors.white30, width: 2),
+                  borderRadius: BorderRadius.all(
+                    Radius.circular(8),
+                  ),
+                ),
+                padding: EdgeInsets.all(defaultPadding),
+                margin: EdgeInsets.only(
+                  top: defaultPadding,
+                  bottom: defaultPadding,
+                ),
+                child: Text(
+                  mission.comment!,
+                ),
+              )
+            ],
+          ),
       ]);
     }
 

--- a/lib/views/components/missionExpansionPanelList.dart
+++ b/lib/views/components/missionExpansionPanelList.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:the_crew_companion/entities/mission.dart';
 import 'package:the_crew_companion/utils/appLocalizations.dart';
 import 'package:the_crew_companion/utils/constant.dart';
+import 'package:the_crew_companion/utils/stringFormatter.dart';
 import 'package:the_crew_companion/views/components/missionDescription.dart';
 
 class MissionExpansionPanelList extends StatefulWidget {
@@ -29,13 +30,6 @@ class _MissionExpansionPanelListState extends State<MissionExpansionPanelList> {
     setState(() {
       expandedMissionId = !isExpanded ? widget.missions[index].id : null;
     });
-  }
-
-  String _printDuration(Duration d) {
-    String twoDigits(int n) => n.toString().padLeft(2, "0");
-    final String twoDigitMinutes = twoDigits(d.inMinutes.remainder(60));
-    final String twoDigitSeconds = twoDigits(d.inSeconds.remainder(60));
-    return "$twoDigitMinutes:$twoDigitSeconds";
   }
 
   List<Widget> buildChildrens(Mission mission) {
@@ -78,7 +72,7 @@ class _MissionExpansionPanelListState extends State<MissionExpansionPanelList> {
             Text(
               mission.durationInSeconds == null
                   ? "-"
-                  : _printDuration(
+                  : StringFormatter.formatDuration(
                       Duration(seconds: mission.durationInSeconds!),
                     ),
             ),

--- a/lib/views/components/missionExpansionPanelList.dart
+++ b/lib/views/components/missionExpansionPanelList.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:the_crew_companion/utils/constant.dart';
 import 'package:the_crew_companion/entities/mission.dart';
 import 'package:the_crew_companion/utils/appLocalizations.dart';
-import 'package:the_crew_companion/views/components/customMarkdownBody.dart';
 import 'package:the_crew_companion/views/components/missionDescription.dart';
 
 class MissionExpansionPanelList extends StatefulWidget {
@@ -34,8 +33,8 @@ class _MissionExpansionPanelListState extends State<MissionExpansionPanelList> {
 
   String _printDuration(Duration d) {
     String twoDigits(int n) => n.toString().padLeft(2, "0");
-    String twoDigitMinutes = twoDigits(d.inMinutes.remainder(60));
-    String twoDigitSeconds = twoDigits(d.inSeconds.remainder(60));
+    final String twoDigitMinutes = twoDigits(d.inMinutes.remainder(60));
+    final String twoDigitSeconds = twoDigits(d.inSeconds.remainder(60));
     return "$twoDigitMinutes:$twoDigitSeconds";
   }
 
@@ -75,7 +74,7 @@ class _MissionExpansionPanelListState extends State<MissionExpansionPanelList> {
         Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
-            Text(AppLocalizations.translate('gameTimeElapsed') + " : "),
+            Text("${AppLocalizations.translate('gameTimeElapsed')} : "),
             Text(
               mission.durationInSeconds == null
                   ? "-"
@@ -89,17 +88,17 @@ class _MissionExpansionPanelListState extends State<MissionExpansionPanelList> {
           Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text(AppLocalizations.translate('commonComments') + " : "),
+              Text("${AppLocalizations.translate('commonComments')} : "),
               Container(
                 width: double.infinity,
                 decoration: BoxDecoration(
                   border: Border.all(color: Colors.white30, width: 2),
-                  borderRadius: BorderRadius.all(
+                  borderRadius: const BorderRadius.all(
                     Radius.circular(8),
                   ),
                 ),
-                padding: EdgeInsets.all(defaultPadding),
-                margin: EdgeInsets.only(
+                padding: const EdgeInsets.all(defaultPadding),
+                margin: const EdgeInsets.only(
                   top: defaultPadding,
                   bottom: defaultPadding,
                 ),

--- a/lib/views/screens/playGameScreen.dart
+++ b/lib/views/screens/playGameScreen.dart
@@ -10,6 +10,7 @@ import 'package:the_crew_companion/entities/mission.dart';
 import 'package:the_crew_companion/entities/team.dart';
 import 'package:the_crew_companion/utils/appLocalizations.dart';
 import 'package:the_crew_companion/utils/constant.dart';
+import 'package:the_crew_companion/utils/stringFormatter.dart';
 import 'package:the_crew_companion/views/components/customDrawer.dart';
 import 'package:the_crew_companion/views/components/missionDescription.dart';
 import 'package:the_crew_companion/views/screens/landscapableScreen.dart';
@@ -78,14 +79,6 @@ class _PlayGameScreenState extends State<PlayGameScreen>
       satUsed = false;
       setState(() {});
     }
-  }
-
-  String _printDuration() {
-    final Duration d = DateTime.now().difference(missionStartDate!);
-    String twoDigits(int n) => n.toString().padLeft(2, "0");
-    final String twoDigitMinutes = twoDigits(d.inMinutes.remainder(60));
-    final String twoDigitSeconds = twoDigits(d.inSeconds.remainder(60));
-    return "$twoDigitMinutes:$twoDigitSeconds";
   }
 
   @override
@@ -175,7 +168,11 @@ class _PlayGameScreenState extends State<PlayGameScreen>
                   children: [
                     Text("${AppLocalizations.translate('gameTimeElapsed')} : "),
                     Text(
-                      missionStartDate == null ? "-" : _printDuration(),
+                      missionStartDate == null
+                          ? "-"
+                          : StringFormatter.formatDuration(
+                              DateTime.now().difference(missionStartDate!),
+                            ),
                     ),
                   ],
                 ),

--- a/lib/views/screens/teamStatsScreen.dart
+++ b/lib/views/screens/teamStatsScreen.dart
@@ -30,9 +30,12 @@ class _TeamStatsScreenState extends State<TeamStatsScreen>
       (achievedMission, i) {
         Mission mission = widget.controller.missions
             .firstWhere((m) => m.id == achievedMission.id)
-            .copyWith();
-        mission.attempts = achievedMission.attempts;
-        mission.satelliteUsed = achievedMission.satelliteUsed;
+            .copyWith(
+              attempts: achievedMission.attempts,
+              satelliteUsed: achievedMission.satelliteUsed,
+              comment: achievedMission.comment,
+              durationInSeconds: achievedMission.durationInSeconds,
+            );
         return mission;
       },
     ).toList();


### PR DESCRIPTION
**Description**

Ajout d'un chronomètre et d'un bloc de commentaire lors de la réalisation d'une mission.
Données consultables dans l'historique d'une équipe.

Pour la saisie, la taille du champs est actuellement limité à 3 lignes (après y'a un scroll).
Par contre l'affichage dans l'historique prend la taille nécessaire au texte

**Screenshots**

![image](https://user-images.githubusercontent.com/1456867/128494435-5cd6ecf4-11e9-40fd-8e83-37ba79572097.png)

![image](https://user-images.githubusercontent.com/1456867/128494393-0e8b00d7-aab9-403c-b3c8-730deacc2208.png)

![image](https://user-images.githubusercontent.com/1456867/128495008-50c6a6bf-e362-4363-89d5-fca03cb1aaa1.png)

![image](https://user-images.githubusercontent.com/1456867/128494457-8212b9b1-7f34-4038-83f0-ade8d82fc5c8.png)

![image](https://user-images.githubusercontent.com/1456867/128494470-c07510d6-d760-43b5-ab45-893fd9a79789.png)